### PR TITLE
FIXED

### DIFF
--- a/app/src/lib/config.ts
+++ b/app/src/lib/config.ts
@@ -1,0 +1,6 @@
+import Constants from 'expo-constants';
+
+// Optional share URL; configurable via app.json -> expo.extra.SHARE_URL
+export const SHARE_URL: string | undefined =
+  (Constants.expoConfig?.extra as any)?.SHARE_URL || undefined;
+

--- a/app/src/lib/share.ts
+++ b/app/src/lib/share.ts
@@ -1,0 +1,25 @@
+type VibeCounts = Record<string, number>;
+
+export function getTopVibe(vibesLastHour?: VibeCounts | null): [string, number] | null {
+  if (!vibesLastHour || typeof vibesLastHour !== 'object') return null;
+  let best: [string, number] | null = null;
+  for (const [emoji, count] of Object.entries(vibesLastHour)) {
+    const c = Number(count) || 0;
+    if (!best || c > best[1]) best = [emoji, c];
+  }
+  return best;
+}
+
+export function formatShare(opts: {
+  name: string;
+  currentPresence?: number;
+  lastHourHits?: number;
+  topVibe?: string | null;
+  link?: string;
+}): string {
+  const { name, currentPresence = 0, lastHourHits = 0, topVibe, link } = opts;
+  const vibePart = topVibe ? ` ${topVibe}` : '';
+  const line = `${name} — ${currentPresence} here now, ${lastHourHits} in last hour${vibePart}`;
+  return link ? `${line}\n${link}` : line;
+}
+


### PR DESCRIPTION
This pull request adds a building stats sharing feature to the app, allowing users to easily share current presence, last hour hits, and the top vibe for a selected building. The implementation includes UI improvements, logic for formatting share messages, and configuration support for a shareable link.

**Building stats sharing feature:**

* Added a share button to the building info sheet UI, enabling users to share building stats via the native share dialog. The button is disabled if stats are not loaded, and provides feedback if unavailable. (`app/App.tsx`)
* Implemented helper functions `getTopVibe` and `formatShare` to extract the most popular vibe and format the share message. (`app/src/lib/share.ts`)
* Added support for a configurable share URL via `expo.extra.SHARE_URL`, which is included in the shared message if available. (`app/src/lib/config.ts`)

**UI improvements:**

* Updated the building info sheet header to display the share button next to the building name, using a new `sheetHeaderRow` style for layout. (`app/App.tsx`, style changes)

**Imports and dependencies:**

* Added imports for sharing, alerts, and toast notifications to support cross-platform feedback for the share action. (`app/App.tsx`)
* Imported new helper functions for sharing logic. (`app/App.tsx`)